### PR TITLE
Minor changes, but significant change for the API

### DIFF
--- a/dockerfile_builder/Cargo.toml
+++ b/dockerfile_builder/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Flexible Dockerfile builder with type-safe features"
 keywords = ["docker", "dockerfile", "dockerfile-builder", "dockerfile-generator"]
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/ptmphuong/dockerfile-builder/"
+repository = "https://github.com/simp4t7/dockerfile-builder/"
 authors = ["Phuong Pham <ptmphuong9@gmail.com>"]
 
 [dependencies]

--- a/dockerfile_builder/src/lib.rs
+++ b/dockerfile_builder/src/lib.rs
@@ -74,6 +74,10 @@ pub struct Dockerfile {
 }
 
 impl Dockerfile {
+    /// Creates a new [Dockerfile], same as `Dockerfile::default()`.
+    pub fn new() -> Self {
+        Self::default()
+    }
     /// Adds an [`Instruction`] to the end of the Dockerfile
     ///
     /// [Instruction]: instruction::Instruction

--- a/dockerfile_builder/src/lib.rs
+++ b/dockerfile_builder/src/lib.rs
@@ -12,8 +12,8 @@
 //!use dockerfile_builder::Dockerfile;
 //!use dockerfile_builder::instruction::{RUN, EXPOSE};
 //!
-//!let dockerfile = Dockerfile::default()
-//!    .push(RUN::from("echo $HOME"))
+//!let mut dockerfile = Dockerfile::default();
+//!    dockerfile.push(RUN::from("echo $HOME"))
 //!    .push(EXPOSE::from("80/tcp"))
 //!    .push_any("# Just adding a comment");
 //!    
@@ -50,8 +50,8 @@
 //!
 //!assert_eq!(expose, expose_from_builder);
 //!
-//!let dockerfile = Dockerfile::default()
-//!    .push(expose_from_builder);
+//!let mut dockerfile = Dockerfile::default();
+//!    dockerfile.push(expose_from_builder);
 //!  
 //!assert_eq!(
 //!    dockerfile.to_string(),
@@ -77,13 +77,13 @@ impl Dockerfile {
     /// Adds an [`Instruction`] to the end of the Dockerfile
     ///
     /// [Instruction]: instruction::Instruction
-    pub fn push<T: Into<Instruction>>(mut self, instruction: T) -> Self {
+    pub fn push<T: Into<Instruction>>(&mut self, instruction: T) -> &mut Self {
         self.instructions.push(instruction.into());
         self
     }
 
     /// Adds any raw string to the end of the Dockerfile
-    pub fn push_any<T: Into<String>>(mut self, instruction: T) -> Self {
+    pub fn push_any<T: Into<String>>(&mut self, instruction: T) -> &mut Self {
         self.instructions.push(Instruction::ANY(instruction.into()));
         self
     }
@@ -91,7 +91,7 @@ impl Dockerfile {
     /// Appends multiple [`Instruction`]s to the end of the Dockerfile
     ///
     /// [Instruction]: instruction::Instruction
-    pub fn append<T: Into<Instruction>>(mut self, instructions: Vec<T>) -> Self {
+    pub fn append<T: Into<Instruction>>(&mut self, instructions: Vec<T>) -> &mut Self {
         for i in instructions {
             self.instructions.push(i.into());
         }
@@ -99,7 +99,7 @@ impl Dockerfile {
     }
 
     /// Appends multiple strings to the end of the Dockerfile
-    pub fn append_any<T: Into<String>>(mut self, instructions: Vec<T>) -> Self {
+    pub fn append_any<T: Into<String>>(&mut self, instructions: Vec<T>) -> &mut Self {
         for i in instructions {
             self.instructions.push(Instruction::ANY(i.into()));
         }
@@ -107,18 +107,21 @@ impl Dockerfile {
     }
 
     /// Adds `syntax` data to the end of the Dockerfile
-    pub fn syntax<T: Into<String>>(self, syntax: T) -> Self {
-        self.push_any(format!("# syntax={}", syntax.into()))
+    pub fn syntax<T: Into<String>>(&mut self, syntax: T) -> &mut Self {
+        self.push_any(format!("# syntax={}", syntax.into()));
+        self
     }
 
     /// Adds `escape` data to the end of the Dockerfile
-    pub fn escape<T: Into<String>>(self, escape: T) -> Self {
-        self.push_any(format!("# escape={}", escape.into()))
+    pub fn escape<T: Into<String>>(&mut self, escape: T) -> &mut Self {
+        self.push_any(format!("# escape={}", escape.into()));
+        self
     }
 
     /// Adds a comment to the end of the Dockerfile
-    pub fn comment<T: Into<String>>(self, comment: T) -> Self {
-        self.push_any(format!("# {}", comment.into()))
+    pub fn comment<T: Into<String>>(&mut self, comment: T) -> &mut Self {
+        self.push_any(format!("# {}", comment.into()));
+        self
     }
 
     /// Retrieves [`Instruction`] vec from Dockerfile
@@ -151,7 +154,8 @@ mod tests {
 
     #[test]
     fn quick_start() {
-        let dockerfile = Dockerfile::default()
+        let mut dockerfile = Dockerfile::default();
+        dockerfile
             .push(RUN::from("echo $HOME"))
             .push(EXPOSE::from("80/tcp"))
             .push_any("# Just adding a comment");
@@ -179,7 +183,8 @@ mod tests {
 
         assert_eq!(expose, expose_from_builder);
 
-        let dockerfile = Dockerfile::default().push(expose_from_builder);
+        let mut dockerfile = Dockerfile::default();
+        dockerfile.push(expose_from_builder);
 
         let expected = expect!["EXPOSE 80/tcp"];
         expected.assert_eq(&dockerfile.to_string());
@@ -193,9 +198,8 @@ mod tests {
             Instruction::RUN(RUN::from("cargo run")),
         ];
 
-        let dockerfile = Dockerfile::default()
-            .append_any(comments)
-            .append(instruction_vec);
+        let mut dockerfile = Dockerfile::default();
+        dockerfile.append_any(comments).append(instruction_vec);
 
         let expected = expect![[r#"
             # syntax=docker/dockerfile:1

--- a/dockerfile_builder/src/lib.rs
+++ b/dockerfile_builder/src/lib.rs
@@ -12,7 +12,7 @@
 //!use dockerfile_builder::Dockerfile;
 //!use dockerfile_builder::instruction::{RUN, EXPOSE};
 //!
-//!let mut dockerfile = Dockerfile::default();
+//!let mut dockerfile = Dockerfile::new();
 //!    dockerfile.push(RUN::from("echo $HOME"))
 //!    .push(EXPOSE::from("80/tcp"))
 //!    .push_any("# Just adding a comment");
@@ -50,7 +50,7 @@
 //!
 //!assert_eq!(expose, expose_from_builder);
 //!
-//!let mut dockerfile = Dockerfile::default();
+//!let mut dockerfile = Dockerfile::new();
 //!    dockerfile.push(expose_from_builder);
 //!  
 //!assert_eq!(
@@ -158,7 +158,7 @@ mod tests {
 
     #[test]
     fn quick_start() {
-        let mut dockerfile = Dockerfile::default();
+        let mut dockerfile = Dockerfile::new();
         dockerfile
             .push(RUN::from("echo $HOME"))
             .push(EXPOSE::from("80/tcp"))
@@ -187,7 +187,7 @@ mod tests {
 
         assert_eq!(expose, expose_from_builder);
 
-        let mut dockerfile = Dockerfile::default();
+        let mut dockerfile = Dockerfile::new();
         dockerfile.push(expose_from_builder);
 
         let expected = expect!["EXPOSE 80/tcp"];
@@ -202,7 +202,7 @@ mod tests {
             Instruction::RUN(RUN::from("cargo run")),
         ];
 
-        let mut dockerfile = Dockerfile::default();
+        let mut dockerfile = Dockerfile::new();
         dockerfile.append_any(comments).append(instruction_vec);
 
         let expected = expect![[r#"


### PR DESCRIPTION
Changed self to &mut self.

Previously:

```Rust
let dockerfile = Dockerfile::default()
    .push(RUN::from("echo $HOME"))
    .push(EXPOSE::from("80/tcp"))
    .push_any("# Just adding a comment");
```

Now:

```Rust
let mut dockerfile = Dockerfile::new;
dockerfile.push(RUN::from("echo $HOME"))
    .push(EXPOSE::from("80/tcp"))
    .push_any("# Just adding a comment");
```

The main reasoning here is to be able to have conditional pushes without having to clone and reassign to keep the dockerfile alive. Basic but helpful for my use-case.